### PR TITLE
Set up development environment + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this repo is
+A large collection of personal technical notes, where each top-level `<Project Name>/README.md` folder is content. The one deployable product is the documentation website in `site/` (Astro + Starlight), which generates its pages at build time from those folders. The Angular app under `OpenFlow on 4112F-ON/angular` and the Python `requirements.txt` files are isolated example artifacts tied to physical hardware, not part of the site.
+
+### The site (`site/`) — the product
+- Requires Node 22 + npm (already available in the environment). Commands and pipeline are documented in `site/README.md` and `site/DEPLOYMENT.md`; don't duplicate them.
+- `npm run dev`/`npm run build` automatically run the content sync (`scripts/sync-content.mjs`) first, so there is no separate sync step needed before running.
+- There are no `lint` or `test` scripts defined for the site — `site/package.json` only has `sync`/`dev`/`start`/`build`/`preview`/`astro`.
+- Dev server (`npm run dev`) serves at `http://localhost:4321`. Cold start is slow (~40s) because the content sync transforms ~130 note folders and many images; wait for the `ready` line before hitting it.
+- Non-obvious: **search is disabled in dev mode**. Pagefind search only works against a production build — run `npm run build` then `npm run preview` to test search locally.
+- `astro-expressive-code` prints harmless `[WARN]` lines for unknown code-block languages (e.g. `dhcp`); these are not errors and the build still completes.
+- Sync warnings (broken/fixed links and images) are written to `site/.generated/sync-report.txt`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the Cloud Agent development environment for this repo. The deployable product is the Astro + Starlight documentation site in `site/`, which generates pages at build time from the `<Project Name>/README.md` folders.

- Verified Node 22 + npm (already present) is the only required toolchain.
- Installed `site/` dependencies and confirmed the full pipeline (content sync → `astro build` → redirect emit) works.
- Ran the dev server and verified the site loads, navigates, and (in production preview) searches end to end.
- Added `AGENTS.md` with `## Cursor Cloud specific instructions` capturing non-obvious caveats (no lint/test scripts, slow ~40s cold start, search only works in production builds, harmless expressive-code warnings).

## Update script
`[ -f site/package.json ] && npm install --prefix site` — minimal, idempotent dependency refresh on startup.

## Walkthrough
[astro_starlight_site_demo.mp4](https://cursor.com/agents/bc-3fe99842-d633-4ec0-a411-c2a8201ada9d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fastro_starlight_site_demo.mp4)
Homepage load, sidebar navigation, and search (production preview) working end to end.

[Homepage](https://cursor.com/agents/bc-3fe99842-d633-4ec0-a411-c2a8201ada9d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsite_homepage.webp)
[Search results for redfish](https://cursor.com/agents/bc-3fe99842-d633-4ec0-a411-c2a8201ada9d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsite_search_results.webp)
[Doc page loaded from search](https://cursor.com/agents/bc-3fe99842-d633-4ec0-a411-c2a8201ada9d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsite_doc_page.webp)

## Testing
- `npm install --prefix site` (succeeds, idempotent)
- `npm run build` in `site/` (173 pages built, Pagefind index built, 170 redirect pages)
- `npm run dev` in `site/` (serves at http://localhost:4321, HTTP 200)
- `npm run preview` (search verified via browser)

No `lint`/`test` scripts are defined for this site.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fe99842-d633-4ec0-a411-c2a8201ada9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fe99842-d633-4ec0-a411-c2a8201ada9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

